### PR TITLE
fix captioners for long ncRNA tutorial

### DIFF
--- a/topics/genome-annotation/tutorials/lncrna/tutorial.md
+++ b/topics/genome-annotation/tutorials/lncrna/tutorial.md
@@ -50,8 +50,7 @@ recordings:
   speakers:
   - rlibouba
   captioners:
-  - stephanierobin
-  - abretaud
+  - rlibouba
   bot-timestamp: 1726077703
 
 


### PR DESCRIPTION
fixed captioners
Sorry for overlooking this earlier.
